### PR TITLE
Add a Gunicorn logging hack.

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,13 +40,18 @@ send `SIGUSR1` to set `INFO` level debugging and `SIGUSR2` to set
 
 ### Running with Gunicorn
 
-If you want access logs, pass `--access-logfile -` to Gunicorn.
+If you want access logs, pass `--access-logfile -` to Gunicorn. If
+you want to override Gunicorn's log format before it starts
+outputting logs, you can supply the `Logger` class from
+`gunicorn_logger`, like this:
+
+```
+gunicorn --logger-class nivacloud_logging.gunicorn_logger.Logger
+```
 
 #### --preload
 
-If you don't want Gunicorn spitting out logs before you have a chance
-to run `setup_logging`, you can start Gunicorn with `--preload`, but
-**ACHTUNG**, if you have code like this...
+Don't use `--preload`, because we have a bunch of code like this:
 
 ```python
 db = MyDb.connect()
@@ -56,12 +61,13 @@ def something():
     db.get("foo")
 ```
 
-...and run Gunicorn with more than one worker process, they may be
-sharing the file descriptors (sockets, in this case) inherited from
-the parent process, and there will be no synchronization between them,
-so in the worst case this may cause data corruption. (It doesn't
-matter if the library used claims to be thread-safe, because these
-are processes, not threads, so they don't know about each other.)
+In cases like this, when you run Gunicorn with more than one worker
+process, they may be sharing the file descriptors (sockets, in this
+case) inherited from the parent process, and there will be no
+synchronization between them, so in the worst case this may cause data
+corruption. (It doesn't matter if the library used claims to be
+thread-safe, because these are processes, not threads, so they don't
+know about each other.)
 
 ### Tracing with Requests
 

--- a/nivacloud_logging/gunicorn_logger.py
+++ b/nivacloud_logging/gunicorn_logger.py
@@ -1,0 +1,10 @@
+import gunicorn.glogging
+
+from nivacloud_logging.log_utils import setup_logging
+
+
+class Logger(gunicorn.glogging.Logger):
+    def __init__(self, cfg):
+        super().__init__(cfg)
+        # Bleh. This feels hacky and awful, but so does Gunicorn...
+        setup_logging(min_level=self.loglevel)

--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,7 @@ OPTIONAL_REQUIREMENTS = {
     'flask': ["Flask>=1.1.0"],
     'aiohttp': ["aiohttp>=3.0.0"],
     'starlette': ["starlette>=0.7.2"],
+    'gunicorn': ["gunicorn>=19.0.0"],
 }
 
 TEST_REQUIREMENTS = [
@@ -20,7 +21,7 @@ setup(
     # Versions should comply with PEP440.  For a discussion on single-sourcing
     # the version across setup.py and the project code, see
     # https://packaging.python.org/en/latest/single_source_version.html
-    version='0.8.2',
+    version='0.8.3rc1',
 
     description="Utils for setting up logging used in nivacloud application",
     long_description_content_type='text/markdown',


### PR DESCRIPTION
With this slightly terrible creation, we don't need to supply the more terrible `--preload`-option to Gunicorn.

I've looked around, and I think the initialization pattern we're using is in fact idiomatic Python, so better just avoid `--preload`, and things will be (mostly) fine.

Another option is to do the database/requests/etc pool initialization with Flask's `Application.before_first_request` method. (Tested, works with *tsb*.)