### PR TITLE
Automatically add "git_commit_id" to LogContext.

### DIFF
--- a/nivacloud_logging/log_utils.py
+++ b/nivacloud_logging/log_utils.py
@@ -64,6 +64,16 @@ class LogContext:
         else:
             return cls.__context.__dict__.get(key)
 
+    @classmethod
+    def update_commit_id(cls, commit_id):
+        """This is only meant to be called from setup_logging."""
+        if commit_id and commit_id != 'unknown':
+            setattr(cls.__context, "git_commit_id", commit_id)
+        # This is here so that multiple tests will work despite breaking
+        # the ordinary context manager-based LogContext contract.
+        elif hasattr(cls.__context, "git_commit_id"):
+            delattr(cls.__context, "git_commit_id")
+
 
 def log_context(**ctxargs):
     """
@@ -299,6 +309,8 @@ def setup_logging(min_level=logging.INFO, plaintext=None, stream=None, override=
 
     if override is None:
         override = os.getenv('NIVACLOUD_OVERRIDE_LOGGERS', '1').lower() in ('1', 'true', 't')
+
+    LogContext.update_commit_id(os.getenv('GIT_COMMIT_ID'))
 
     # This is a work-around to be able to run tests with pytest's output
     # capture when threading. (It doesn't work when you set it as a

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     # Versions should comply with PEP440.  For a discussion on single-sourcing
     # the version across setup.py and the project code, see
     # https://packaging.python.org/en/latest/single_source_version.html
-    version='0.8.4',
+    version='0.8.5rc1',
 
     description="Utils for setting up logging used in nivacloud application",
     long_description_content_type='text/markdown',

--- a/tests/test_structured_logging.py
+++ b/tests/test_structured_logging.py
@@ -376,3 +376,23 @@ def test_signal_handler_override_should_call_previous_handlers(capsys):
     log_json = _readout_json(capsys)
     assert log_json['message'] == 'Debugged!'
     assert myhandler_run_count == 2
+
+
+def test_should_add_commit_it_from_environment(capsys, monkeypatch):
+    monkeypatch.setenv('GIT_COMMIT_ID', 'd22b929')
+    setup_logging()
+    logging.info('Something committed')
+
+    log_json = _readout_json(capsys)
+    assert log_json['message'] == 'Something committed'
+    assert log_json['git_commit_id'] == 'd22b929'
+
+
+def test_should_not_add_commit_id_context_on_missing_env(capsys, monkeypatch):
+    monkeypatch.setenv('GIT_COMMIT_ID', '')
+    setup_logging()
+    logging.info('Something committed')
+
+    log_json = _readout_json(capsys)
+    assert log_json['message'] == 'Something committed'
+    assert 'git_commit_id' not in log_json


### PR DESCRIPTION
I don't really love this, but it adds Git commit ID to everything that uses nivacloud-logging pretty easily.

https://github.com/NIVANorge/nivacloud/issues/455